### PR TITLE
[BAC-13][BAC-51] Backend 유저 회원가입 및 회원가입 인증 메일 승인

### DIFF
--- a/backend/src/main/java/com/example/backswim/member/controller/JoinMemberController.java
+++ b/backend/src/main/java/com/example/backswim/member/controller/JoinMemberController.java
@@ -23,7 +23,7 @@ public class JoinMemberController extends CommonController {
     public APIResult<Boolean> joinMember(HttpServletRequest request, JoinMemberParam param){
         if(!param.checkStatus()){
             PrintLog(request);
-            return new APIResult<>(400,false, StatusEnum.BAD_REQUEST);
+            return new APIResult<>(400,null, StatusEnum.BAD_REQUEST);
         }
         try{
             if(!userService.joinMember(param)){
@@ -33,7 +33,7 @@ public class JoinMemberController extends CommonController {
         }catch(Exception e){
             PrintErrorLog(request);
             e.printStackTrace();
-            return new APIResult<>(500, false, StatusEnum.INTERNAL_SERVER_ERROR);
+            return new APIResult<>(500, null, StatusEnum.INTERNAL_SERVER_ERROR);
         }
         return new APIResult<>(200,true,StatusEnum.OK);
     }

--- a/backend/src/main/java/com/example/backswim/member/entity/UserEntity.java
+++ b/backend/src/main/java/com/example/backswim/member/entity/UserEntity.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 public class UserEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Integer seq;
 
     @NotNull

--- a/backend/src/main/java/com/example/backswim/member/params/JoinMemberParam.java
+++ b/backend/src/main/java/com/example/backswim/member/params/JoinMemberParam.java
@@ -23,4 +23,9 @@ public class JoinMemberParam extends CheckDuplicateID {
         return true;
     }
 
+    public JoinMemberParam(String email ,String password){
+        super(email);
+        this.password = password;
+    }
+
 }

--- a/backend/src/main/java/com/example/backswim/member/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/example/backswim/member/service/UserServiceImpl.java
@@ -43,7 +43,6 @@ public class UserServiceImpl implements UserService{
                 .password(encPassword)
                 .emailAuthKey(uuid)
                 .regdate(LocalDateTime.now())
-                .emailAuthDate(LocalDateTime.now())
                 .build();
 
         userRepository.save(userEntity);

--- a/backend/src/test/java/com/example/backswim/UserJoinTest.java
+++ b/backend/src/test/java/com/example/backswim/UserJoinTest.java
@@ -1,14 +1,34 @@
 package com.example.backswim;
 
+import com.example.backswim.member.params.CheckDuplicateID;
+import com.example.backswim.member.params.JoinMemberParam;
+import com.example.backswim.pool.params.SearchAddressParam;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -22,5 +42,137 @@ public class UserJoinTest {
                 .addFilters(new CharacterEncodingFilter("UTF-8",true))
                 .alwaysDo(print())
                 .build();
+    }
+
+
+    static Stream<Arguments> CheckDuplicateID(){
+        return Stream.of(
+                Arguments.arguments(new CheckDuplicateID("jk960903@naver.com")),
+                Arguments.arguments(new CheckDuplicateID("benzen903@gmail.com")),
+                Arguments.arguments(new CheckDuplicateID("benzen903@kakao.com")),
+                Arguments.arguments(new CheckDuplicateID("jk960903@gmail.com"))
+
+        );
+    }
+
+    static Stream<Arguments> CheckDuplicateFailID(){
+        return Stream.of(
+                Arguments.arguments(new CheckDuplicateID(null)),
+                Arguments.arguments(new CheckDuplicateID("jk960903")),
+                Arguments.arguments(new CheckDuplicateID("123455555")),
+                Arguments.arguments(new CheckDuplicateID("zewsqqq"))
+
+        );
+    }
+
+    static Stream<Arguments> AddMemberSuccess(){
+        return Stream.of(
+                Arguments.arguments(new JoinMemberParam("benzen903@gmail.com","!@#asdf!@#")),
+                Arguments.arguments(new JoinMemberParam("jk960903@naver.com","!@#asdf!@#")),
+                Arguments.arguments(new JoinMemberParam("jk960903@gmail.com","!@#asdf!@#")),
+                Arguments.arguments(new JoinMemberParam("benzen903@kakao.com","!@#asdf!@#"))
+        );
+    }
+
+    static Stream<Arguments> AddMemberFail(){
+        return Stream.of(
+                Arguments.arguments(new JoinMemberParam("benzen903","!@#asdf!@#")),
+                Arguments.arguments(new JoinMemberParam("","!@#asdf!@#")),
+                Arguments.arguments(new JoinMemberParam("jk960903@gmail.com","")),
+                Arguments.arguments(new JoinMemberParam())
+        );
+    }
+
+    //15ms
+    @DisplayName("이메일 중복체크 API 성공 테스트")
+    @ParameterizedTest(name="/api/joinmember/duplicateid")
+    @MethodSource("CheckDuplicateID")
+    public void checkDuplicateSuccessTest(CheckDuplicateID param) throws Exception{
+
+        MultiValueMap<String ,String> map = new LinkedMultiValueMap<>();
+
+        map.add("userEmail",param.getUserEmail());
+        mockMvc.perform(post("/api/joinmember/duplicateid").params(map).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode",is(200)))
+                .andExpect(jsonPath("$.data",is(true)));
+    }
+
+    //15ms
+    @DisplayName("이메일 중복체크 API 실패 테스트")
+    @ParameterizedTest(name="/api/joinmember/duplicateid")
+    @MethodSource("CheckDuplicateFailID")
+    public void checkDuplicateFailTest(CheckDuplicateID param) throws Exception{
+        MultiValueMap<String ,String> map = new LinkedMultiValueMap<>();
+
+        map.add("userEmail",param.getUserEmail());
+
+        mockMvc.perform(post("/api/joinmember/duplicateid").params(map).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode",is(400)))
+                .andExpect(jsonPath("$.data",nullValue()));
+    }
+    //2~3sec
+    @DisplayName("회원가입 API 성공 TEST")
+    @ParameterizedTest(name="/api/joinmember/addmember")
+    @MethodSource("AddMemberSuccess")
+    public void addMemberSuccessTest(JoinMemberParam param) throws Exception{
+        MultiValueMap<String ,String> map = new LinkedMultiValueMap<>();
+
+        map.add("userEmail",param.getUserEmail());
+        map.add("password",param.getPassword());
+
+
+        mockMvc.perform(post("/api/joinmember/addmember").params(map).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode",is(200)))
+                .andExpect(jsonPath("$.data",is(true)));
+    }
+    //12ms
+    @DisplayName("회원가입 API 실패 Fail Parameter")
+    @ParameterizedTest(name="/api/joinmember/addmember")
+    @MethodSource("AddMemberFail")
+    public void addMemberFailTest(JoinMemberParam param) throws Exception{
+        MultiValueMap<String ,String> map = new LinkedMultiValueMap<>();
+
+        map.add("userEmail",param.getUserEmail());
+        map.add("password",param.getPassword());
+
+
+        mockMvc.perform(post("/api/joinmember/addmember").params(map).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode",is(400)))
+                .andExpect(jsonPath("$.data",nullValue()));
+    }
+
+    //12ms
+    @DisplayName("EmailAuthSuccess Test")
+    @ParameterizedTest(name="/api/joinmember/email-auth")
+    @ValueSource(strings = {"b1e05373-d279-4516-adf1-aaaa5f49f0a7","4cc09bbb-fe1b-4060-a963-7cea330717eb","451c6981-95fa-4bec-a526-7c9dc213b498","afeb9e76-0840-4674-92a0-dcd7ab2d4b35"})
+    public void EmailAuthSuccessTest(String param) throws Exception{
+        MultiValueMap<String ,String> map = new LinkedMultiValueMap<>();
+
+        map.add("uuid",param);
+
+        mockMvc.perform(get("/api/joinmember/email-auth").params(map).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode",is(200)))
+                .andExpect(jsonPath("$.data",is(true)))
+                .andExpect(jsonPath("$.message",is("OK")));
+    }
+    //8ms
+    @DisplayName("EmailAuthSuccess Test")
+    @ParameterizedTest(name="/api/joinmember/email-auth")
+    @ValueSource(strings = {"b1e05373-d279-4516-adf1-aaaa5f49f0a7","4cc09bbb-fe1b-4060-a963-7cea330717eb","451c6981-95fa-4bec-a526-7c9dc213b498","afeb9e76-0840-4674-92a0-dcd7ab2d4b35"})
+    public void EmailAuthFailTest(String param) throws Exception{
+        MultiValueMap<String ,String> map = new LinkedMultiValueMap<>();
+
+        map.add("uuid",param);
+
+        mockMvc.perform(get("/api/joinmember/email-auth").params(map).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode",is(200)))
+                .andExpect(jsonPath("$.data",is(false)))
+                .andExpect(jsonPath("$.message",is("OK")));
     }
 }


### PR DESCRIPTION
 지적사항 수정 및 테스트 코드 작성

테스트 코드
각각의 테스트 케이스는 1회용입니다.
* 실제 DB에 저장되고 이메일이 발송되어 재사용이 불가능하여 이후 DB제어를 해주어야합니다.

* checkDuplicateSuccessTest 이메일 중복체크 API Success Test
 runtime 12ms ~ 15ms

* checkDuplicateFailTest 이메일 중복체크 API Fail Test
 중복된 데이터가 들어가있거나 잘못된 입력값 , 이메일 형식이 아닌경우를 모두 포함합니다.
 runtime 8~15ms

* addMemberSuccesstest 회원가입 API 성공 TEST
runtime 2~3.5Sec

* addMemberFailTest
 runtime 8ms ~ 15ms
 중복된 데이터가 들어가있거나 잘못된 입력값 , 이메일 형식이 아닌경우를 모두 포함합니다.

* EmailAuthSuccessTest 이메일 인증 API 성공 테스트
 runtime 12ms ~ 15ms

* EmailAuthFailTest 이메일 인증 API 실패 테스트
 이미 인증한 uuid 에 대해 fail 테스트입니다.
 runtime 8~11ms